### PR TITLE
修复`flat()`错误的操作参数list，导致引用传递被异常修改的问题

### DIFF
--- a/brv/src/main/java/com/drake/brv/BindingAdapter.kt
+++ b/brv/src/main/java/com/drake/brv/BindingAdapter.kt
@@ -588,11 +588,10 @@ open class BindingAdapter : RecyclerView.Adapter<BindingAdapter.BindingViewHolde
     ): MutableList<Any?> {
 
         if (list.isEmpty()) return list
-        val arrayList = ArrayList(list)
-        list.clear()
+        val arrayList = arrayListOf<Any?>()
 
-        arrayList.forEachIndexed { index, item ->
-            list.add(item)
+        list.forEachIndexed { index, item ->
+            arrayList.add(item)
             if (item is ItemExpand) {
                 item.itemGroupPosition = index
                 var nextDepth = depth
@@ -606,11 +605,11 @@ open class BindingAdapter : RecyclerView.Adapter<BindingAdapter.BindingViewHolde
                     if (itemSublist is ArrayList) itemSublist else itemSublist?.toMutableList()
                 if (!sublist.isNullOrEmpty() && (item.itemExpand || (depth != 0 && expand != null))) {
                     val nestedList = flat(sublist, expand, nextDepth)
-                    list.addAll(nestedList)
+                    arrayList.addAll(nestedList)
                 }
             }
         }
-        return list
+        return arrayList
     }
 
     /**

--- a/docs/refresh.md
+++ b/docs/refresh.md
@@ -36,7 +36,7 @@ implementation  'com.scwang.smart:refresh-footer-classics:2.0.1'    //经典加�
 刷新布局要求必须先初始化, 推荐在Application中
 
 ```
-SmartRefreshLayout.setDefaultRefreshHeaderCreator { context, layout -> ClassicsHeader(this) }
+SmartRefreshLayout.setDefaultRefreshHeaderCreator { context, layout -> MaterialHeader(this) }
 SmartRefreshLayout.setDefaultRefreshFooterCreator { context, layout -> ClassicsFooter(this) }
 ```
 


### PR DESCRIPTION
flat()中参数list，由于是引用传递，在分组情况下会错误的修改源数据，导致子项越来越多。