### PR TITLE
修复分组源数据被错误的修改。

### DIFF
--- a/brv/src/main/java/com/drake/brv/BindingAdapter.kt
+++ b/brv/src/main/java/com/drake/brv/BindingAdapter.kt
@@ -602,10 +602,8 @@ open class BindingAdapter : RecyclerView.Adapter<BindingAdapter.BindingViewHolde
                 }
 
                 val itemSublist = item.itemSublist
-                val sublist: MutableList<Any?>? =
-                    if (itemSublist is ArrayList) itemSublist else itemSublist?.toMutableList()
-                if (!sublist.isNullOrEmpty() && (item.itemExpand || (depth != 0 && expand != null))) {
-                    val nestedList = flat(sublist, expand, nextDepth)
+                if (!itemSublist.isNullOrEmpty() && (item.itemExpand || (depth != 0 && expand != null))) {
+                    val nestedList = flat(ArrayList(itemSublist), expand, nextDepth)
                     list.addAll(nestedList)
                 }
             }
@@ -1054,9 +1052,7 @@ open class BindingAdapter : RecyclerView.Adapter<BindingAdapter.BindingViewHolde
                     previousExpandPosition = realPosition
                     0
                 } else {
-                    val sublist =
-                        if (itemSublist is ArrayList) itemSublist else itemSublist.toMutableList()
-                    val sublistFlat = flat(sublist, true, depth)
+                    val sublistFlat = flat(ArrayList(itemSublist), true, depth)
 
                     (this@BindingAdapter.models as MutableList).addAll(
                         realPosition + 1,
@@ -1097,9 +1093,7 @@ open class BindingAdapter : RecyclerView.Adapter<BindingAdapter.BindingViewHolde
                     notifyItemChanged(layoutPosition, itemExpand)
                     0
                 } else {
-                    val sublist =
-                        if (itemSublist is ArrayList) itemSublist else itemSublist.toMutableList()
-                    val sublistFlat = flat(sublist, false, depth)
+                    val sublistFlat = flat(ArrayList(itemSublist), false, depth)
                     (this@BindingAdapter.models as MutableList).removeAll(sublistFlat)
                     if (expandAnimationEnabled) {
                         notifyItemChanged(layoutPosition, itemExpand)

--- a/docs/refresh.md
+++ b/docs/refresh.md
@@ -36,7 +36,7 @@ implementation  'com.scwang.smart:refresh-footer-classics:2.0.1'    //经典加�
 刷新布局要求必须先初始化, 推荐在Application中
 
 ```
-SmartRefreshLayout.setDefaultRefreshHeaderCreator { context, layout -> ClassicsHeader(this) }
+SmartRefreshLayout.setDefaultRefreshHeaderCreator { context, layout -> MaterialHeader(this) }
 SmartRefreshLayout.setDefaultRefreshFooterCreator { context, layout -> ClassicsFooter(this) }
 ```
 


### PR DESCRIPTION
修复`expand()`和`collapse()`flat`itemSublist`数据时，传递了源数据，导致源数据在`flat()`被错误修改的问题