### PR TITLE
fixed: 修复分组深度计算错误

### DIFF
--- a/brv/src/main/java/com/drake/brv/item/ItemDepth.kt
+++ b/brv/src/main/java/com/drake/brv/item/ItemDepth.kt
@@ -40,7 +40,7 @@ interface ItemDepth {
             }
             if (item is ItemExpand) {
                 item.itemSublist?.run {
-                    refreshItemDepth(models, initDepth + 1)
+                    refreshItemDepth(this, initDepth + 1)
                 }
             }
         }


### PR DESCRIPTION
com.drake.brv.item.ItemDepth$Companion.refreshItemDepth: `java.lang.StackOverflowError: stack size 8192KB`
ebfc4526171fcc86acde4f3fc1d7a8f45ef4f774 迁移时，`refreshItemDepth`递归目标错误，导致死循环。