### PR TITLE
优化bindingAdapter在开启dataBindingEnable时，某些情况存在inflate两次布局的问题

### DIFF
--- a/brv/src/main/java/com/drake/brv/BindingAdapter.kt
+++ b/brv/src/main/java/com/drake/brv/BindingAdapter.kt
@@ -151,25 +151,24 @@ open class BindingAdapter : RecyclerView.Adapter<BindingAdapter.BindingViewHolde
     private var context: Context? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BindingViewHolder {
+        val itemView = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
         val vh = if (dataBindingEnable) {
-            val viewBinding = DataBindingUtil.inflate<ViewDataBinding>(
-                LayoutInflater.from(parent.context), viewType, parent, false
-            )
+            val viewBinding = try {
+                DataBindingUtil.bind<ViewDataBinding>(itemView)
+            } catch (e: Throwable) {
+                null
+            }
             if (viewBinding == null) {
-                BindingViewHolder(parent.getView(viewType))
+                BindingViewHolder(itemView)
             } else {
                 BindingViewHolder(viewBinding)
             }
         } else {
-            BindingViewHolder(parent.getView(viewType))
+            BindingViewHolder(itemView)
         }
         RecyclerViewUtils.setItemViewType(vh, viewType)
         onCreate?.invoke(vh, viewType)
         return vh
-    }
-
-    fun ViewGroup.getView(@LayoutRes layout: Int): View {
-        return LayoutInflater.from(context).inflate(layout, this, false)
     }
 
     override fun onBindViewHolder(holder: BindingViewHolder, position: Int) {
@@ -189,17 +188,13 @@ open class BindingAdapter : RecyclerView.Adapter<BindingAdapter.BindingViewHolde
     }
 
     override fun getItemViewType(position: Int): Int {
-
         val model = getModel<Any>(position)
         val modelClass: Class<*> = model.javaClass
-        return (typePool[modelClass]?.invoke(model, position) ?: interfacePool?.run {
-            for (interfaceType in this) {
-                if (interfaceType.key.isAssignableFrom(modelClass)) {
-                    return@run interfaceType.value.invoke(model, position)
-                }
-            }
-            null
-        } ?: throw NoSuchPropertyException("please add item model type : addType<${model.javaClass.name}>(R.layout.item)"))
+        return typePool[modelClass]?.invoke(model, position)
+            ?: interfacePool?.firstNotNullOfOrNull {
+                if (it.key.isAssignableFrom(modelClass)) it.value else null
+            }?.invoke(model, position)
+            ?: throw NoSuchPropertyException("please add item model type : addType<${model.javaClass.name}>(R.layout.item)")
     }
 
     override fun getItemCount(): Int {


### PR DESCRIPTION
在dataBindingEnable = true时，如果布局不支持databinding，那么DataBindingUtil.inflate方法内部会先inflate一次布局，发现binding = null,此时再重新inflate布局，导致同一个布局被inflate两次，因此目前改为在开启的情况下，先inflate布局，然后再从布局中找到binding，这样子在特殊情况下减少了一次布局的inflate