### PR TITLE
fix: 修复水平/垂直分割线的 drawable 有宽度/高度时会导致分割线被拉伸的问题

### DIFF
--- a/brv/src/main/java/com/drake/brv/DefaultDecoration.kt
+++ b/brv/src/main/java/com/drake/brv/DefaultDecoration.kt
@@ -116,6 +116,7 @@ class DefaultDecoration constructor(private val context: Context) : RecyclerView
     private var marginBaseItemStart = false
     private var marginBaseItemEnd = false
     private var divider: Drawable? = null
+    private var stretchDivider: Boolean = true
 
     //<editor-fold desc="类型">
 
@@ -156,18 +157,24 @@ class DefaultDecoration constructor(private val context: Context) : RecyclerView
 
     /**
      * 将图片作为分割线, 图片宽高即分割线宽高
+     *
+     * @param stretch 是否拉伸图片, 默认为 true
      */
-    fun setDrawable(drawable: Drawable) {
+    fun setDrawable(drawable: Drawable, stretch: Boolean = true) {
         divider = drawable
+        this.stretchDivider = stretch
     }
 
     /**
      * 将图片作为分割线, 图片宽高即分割线宽高
+     *
+     * @param stretch 是否拉伸图片, 默认为 true
      */
-    fun setDrawable(@DrawableRes drawableRes: Int) {
+    fun setDrawable(@DrawableRes drawableRes: Int, stretch: Boolean = true) {
         val drawable = ContextCompat.getDrawable(context, drawableRes)
             ?: throw IllegalArgumentException("Drawable cannot be find")
         divider = drawable
+        this.stretchDivider = stretch
     }
     //</editor-fold>
 
@@ -506,7 +513,7 @@ class DefaultDecoration constructor(private val context: Context) : RecyclerView
                     bottom = decoratedBounds.bottom
                     top = if (intrinsicHeight == -1) bottom - size else bottom - intrinsicHeight
                 }
-                if (intrinsicWidth != -1) {
+                if (intrinsicWidth != -1 && stretchDivider.not()) {
                     val centerHorizontal = (left + right) / 2
                     left = centerHorizontal - intrinsicWidth / 2
                     right = centerHorizontal + intrinsicWidth / 2
@@ -571,7 +578,7 @@ class DefaultDecoration constructor(private val context: Context) : RecyclerView
 
                 val right = (decoratedBounds.right + child.translationX).roundToInt()
                 val left = if (intrinsicWidth == -1) right - size else right - intrinsicWidth
-                if (intrinsicHeight != -1) {
+                if (intrinsicHeight != -1 && stretchDivider.not()) {
                     val centerVertical = (top + bottom) / 2
                     top = centerVertical - intrinsicHeight / 2
                     bottom = centerVertical + intrinsicHeight / 2

--- a/brv/src/main/java/com/drake/brv/DefaultDecoration.kt
+++ b/brv/src/main/java/com/drake/brv/DefaultDecoration.kt
@@ -453,8 +453,8 @@ class DefaultDecoration constructor(private val context: Context) : RecyclerView
      */
     private fun drawHorizontal(canvas: Canvas, parent: RecyclerView, reverseLayout: Boolean) {
         canvas.save()
-        val left: Int
-        val right: Int
+        var left: Int
+        var right: Int
 
         if (parent.clipToPadding) {
             left = parent.paddingLeft + this.marginStart
@@ -506,6 +506,11 @@ class DefaultDecoration constructor(private val context: Context) : RecyclerView
                     bottom = decoratedBounds.bottom
                     top = if (intrinsicHeight == -1) bottom - size else bottom - intrinsicHeight
                 }
+                if (intrinsicWidth != -1) {
+                    val centerHorizontal = (left + right) / 2
+                    left = centerHorizontal - intrinsicWidth / 2
+                    right = centerHorizontal + intrinsicWidth / 2
+                }
 
                 if (startVisible && if (reverseLayout) edge.bottom else edge.top) {
                     setBounds(left, firstTop, right, firstBottom)
@@ -524,8 +529,8 @@ class DefaultDecoration constructor(private val context: Context) : RecyclerView
      */
     private fun drawVertical(canvas: Canvas, parent: RecyclerView, reverseLayout: Boolean) {
         canvas.save()
-        val top: Int
-        val bottom: Int
+        var top: Int
+        var bottom: Int
 
         if (parent.clipToPadding) {
             top = parent.paddingTop + marginStart
@@ -566,6 +571,11 @@ class DefaultDecoration constructor(private val context: Context) : RecyclerView
 
                 val right = (decoratedBounds.right + child.translationX).roundToInt()
                 val left = if (intrinsicWidth == -1) right - size else right - intrinsicWidth
+                if (intrinsicHeight != -1) {
+                    val centerVertical = (top + bottom) / 2
+                    top = centerVertical - intrinsicHeight / 2
+                    bottom = centerVertical + intrinsicHeight / 2
+                }
 
                 if (startVisible && edge.left) {
                     setBounds(firstLeft, top, firstRight, bottom)

--- a/brv/src/main/java/com/drake/brv/utils/RecyclerUtils.kt
+++ b/brv/src/main/java/com/drake/brv/utils/RecyclerUtils.kt
@@ -192,13 +192,15 @@ fun RecyclerView.divider(
  * 指定Drawable资源为分割线, 分割线的间距和宽度应在资源文件中配置
  * @param drawable 描述分割线的drawable
  * @param orientation 分割线方向, 仅[androidx.recyclerview.widget.GridLayoutManager]需要使用此参数, 其他LayoutManager都是根据其方向自动推断
+ * @param stretch 是否拉伸图片, 默认为 true
  */
 fun RecyclerView.divider(
     @DrawableRes drawable: Int,
-    orientation: DividerOrientation = DividerOrientation.HORIZONTAL
+    orientation: DividerOrientation = DividerOrientation.HORIZONTAL,
+    stretch: Boolean = true
 ): RecyclerView {
     return divider {
-        setDrawable(drawable)
+        setDrawable(drawable, stretch)
         this.orientation = orientation
     }
 }


### PR DESCRIPTION
复现方法：

```kotlin
binding.rv.linear(RecyclerView.HORIZONTAL).divider(R.drawable.divider_vertical_xxhdpi)
```

所用图片为（放到 _drawable-xxhdpi_）：

![divider_vertical_xxhdpi](https://github.com/liangjingkanji/BRV/assets/43238557/558898bf-1035-41bb-9850-653c14577ae1)

> **PS：我只修复了垂直和水平分割线，网格分割线看着有点复杂，我没修，你可以看一看**