### PR TITLE
修复PageRefreshLayout的refreshing后，快速finish导致永久无法刷新的问题

### DIFF
--- a/brv/src/main/java/com/drake/brv/PageRefreshLayout.kt
+++ b/brv/src/main/java/com/drake/brv/PageRefreshLayout.kt
@@ -253,7 +253,7 @@ open class PageRefreshLayout : SmartRefreshLayout, OnRefreshLoadMoreListener {
      */
     fun refresh() {
         if (state == RefreshState.None) {
-            notifyStateChanged(RefreshState.PullDownToRefresh)
+            notifyStateChanged(RefreshState.Refreshing)
             onRefresh(this)
         }
     }
@@ -451,7 +451,9 @@ open class PageRefreshLayout : SmartRefreshLayout, OnRefreshLoadMoreListener {
         success: Boolean,
         noMoreData: Boolean?
     ): RefreshLayout {
-        super.finishRefresh(delayed, success, noMoreData)
+        post {
+            super.finishRefresh(delayed, success, noMoreData)
+        }
         if (!mEnableLoadMoreWhenContentNotFull) {
             setEnableLoadMoreWhenContentNotFull(noMoreData == false || !mFooterNoMoreData)
         }
@@ -681,7 +683,7 @@ open class PageRefreshLayout : SmartRefreshLayout, OnRefreshLoadMoreListener {
             state.loadingLayout = loadingLayout
             state.onRefresh {
                 if (realEnableRefresh) super.setEnableRefresh(false)
-                notifyStateChanged(RefreshState.PullDownToRefresh)
+                notifyStateChanged(RefreshState.Refreshing)
                 onRefresh(this@PageRefreshLayout)
             }
         }


### PR DESCRIPTION
修复PageRefreshLayout的refreshing后，快速finish导致永久无法刷新的问题
目前测试下来没有问题，之前的PR方案会导致无法autoRefresh()
我考虑到的几个finish都测了，没有问题