### PR TITLE
fix: 修复判断条目是否在同一分组下的取值错误

### DIFF
--- a/brv/src/main/java/com/drake/brv/BindingAdapter.kt
+++ b/brv/src/main/java/com/drake/brv/BindingAdapter.kt
@@ -1000,7 +1000,7 @@ open class BindingAdapter : RecyclerView.Adapter<BindingAdapter.BindingViewHolde
         @IntRange(from = 0) position: Int,
         @IntRange(from = 0) otherPosition: Int,
     ): Boolean {
-        val aModel = models?.getOrNull(otherPosition) ?: return false
+        val aModel = models?.getOrNull(position) ?: return false
         val bModel = models?.getOrNull(otherPosition) ?: return false
         for (index in min(position, otherPosition) - 1 downTo 0) {
             val item = models?.getOrNull(index) ?: break


### PR DESCRIPTION
详细内容：
1. BindingAdapter.isSameGroup 方法内部变量 aModel 与 bModel 取值索引相同，应和入参一致