### PR TITLE
修复:当models未被初始化时为null且没有设置过checkableItemTypeList时，

### DIFF
--- a/brv/src/main/java/com/drake/brv/BindingAdapter.kt
+++ b/brv/src/main/java/com/drake/brv/BindingAdapter.kt
@@ -845,7 +845,8 @@ open class BindingAdapter : RecyclerView.Adapter<BindingAdapter.BindingViewHolde
         get() {
             var count = 0
             if (checkableItemTypeList == null) {
-                return models!!.size
+                //安全调用 models，如果为 null 则返回 0
+                return models?.size ?:0
             } else {
                 for (i in 0 until itemCount) {
                     if (checkableItemTypeList!!.contains(getItemViewType(i))) {


### PR DESCRIPTION
 就会走return models!!.size
 触发NullPointException